### PR TITLE
Remove unnecessary requirements

### DIFF
--- a/Python/Cogs/giveaway/requirements.txt
+++ b/Python/Cogs/giveaway/requirements.txt
@@ -1,4 +1,2 @@
 git+https://github.com/Pycord-Development/pycord
-typing
 asyncio
-util

--- a/Python/global-req.txt
+++ b/Python/global-req.txt
@@ -1,5 +1,4 @@
 git+https://github.com/Pycord-Development/pycord
-typing
 asyncio
 youtube-dl
 pynacl


### PR DESCRIPTION
1. `typing` is a default python package
2. you import `util` from a file not from a module